### PR TITLE
Stale PR labelling

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,5 +17,5 @@ jobs:
           days-before-pr-close: -1 # We don't want to close PR in this action
           stale-pr-label: stale
           stale-pr-message: |
-            This PR has been automatically marked as stale because it has not had recent activity.
+            This PR has been automatically marked as stale because it has no activity for 30 days.
             Please add a comment if you want to keep the issue open. Thank you for your contributions!

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: "Label stale PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: -1 # We don't want to address issues
+          days-before-pr-stale: 30
+          days-before-issue-close: -1 # We don't want to close issues in this action
+          days-before-pr-close: -1 # We don't want to close PR in this action
+          stale-pr-label: stale
+          stale-pr-message: |
+            This PR has been automatically marked as stale because it has not had recent activity.
+            Please add a comment if you want to keep the issue open. Thank you for your contributions!


### PR DESCRIPTION
This PR adds a GitHub Actions workflow in charge of labelling stale PR with 'stale' after 30 days of inactivity.